### PR TITLE
menuEntry external link

### DIFF
--- a/dist/index.cjs.js
+++ b/dist/index.cjs.js
@@ -4240,8 +4240,12 @@ var PanelBody = function (_a) {
                         React__default['default'].createElement(LinkLabelMemo, { isPushed: isPushed }, item.label),
                         item.status && (React__default['default'].createElement(LinkStatus, { color: item.status.color, fontSize: "14px" }, item.status.text))))); })));
         }
+        var menuLinkProps = { href: entry.href, onClick: handleClick };
+        if (entry.external === true) {
+            Object.assign(menuLinkProps, getExternalLinkProps());
+        }
         return (React__default['default'].createElement(MenuEntry, { key: entry.label, isActive: entry.href === location.pathname, className: calloutClass },
-            React__default['default'].createElement(MenuLink, { href: entry.href, onClick: handleClick },
+            React__default['default'].createElement(MenuLink, menuLinkProps,
                 iconElement,
                 React__default['default'].createElement(LinkLabelMemo, { isPushed: isPushed }, entry.label),
                 entry.status && (React__default['default'].createElement(LinkStatus, { color: entry.status.color, fontSize: "14px" }, entry.status.text)))));

--- a/dist/index.cjs.js
+++ b/dist/index.cjs.js
@@ -4235,8 +4235,13 @@ var PanelBody = function (_a) {
             var itemsMatchIndex = entry.items.findIndex(function (item) { return item.href === location.pathname; });
             var initialOpenState = entry.initialOpenState === true ? entry.initialOpenState : itemsMatchIndex >= 0;
             return (React__default['default'].createElement(Accordion, { key: entry.label, isPushed: isPushed, pushNav: pushNav, icon: iconElement, label: entry.label, status: entry.status, initialOpenState: initialOpenState, className: calloutClass, isActive: entry.items.some(function (item) { return item.href === location.pathname; }) }, isPushed &&
-                entry.items.map(function (item) { return (React__default['default'].createElement(MenuEntry, { key: item.href, secondary: true, isActive: item.href === location.pathname, onClick: handleClick },
-                    React__default['default'].createElement(MenuLink, { href: item.href },
+                entry.items.map(function (item) { 
+                    var menuItemLinkProps = { href: item.href };
+                    if (item.external === true) {
+                        Object.assign(menuItemLinkProps, getExternalLinkProps());
+                    }
+                    return (React__default['default'].createElement(MenuEntry, { key: item.href, secondary: true, isActive: item.href === location.pathname, onClick: handleClick },
+                    React__default['default'].createElement(MenuLink, menuItemLinkProps,
                         React__default['default'].createElement(LinkLabelMemo, { isPushed: isPushed }, item.label),
                         item.status && (React__default['default'].createElement(LinkStatus, { color: item.status.color, fontSize: "14px" }, item.status.text))))); })));
         }

--- a/dist/index.esm.js
+++ b/dist/index.esm.js
@@ -4232,8 +4232,13 @@ var PanelBody = function (_a) {
             var itemsMatchIndex = entry.items.findIndex(function (item) { return item.href === location.pathname; });
             var initialOpenState = entry.initialOpenState === true ? entry.initialOpenState : itemsMatchIndex >= 0;
             return (React.createElement(Accordion, { key: entry.label, isPushed: isPushed, pushNav: pushNav, icon: iconElement, label: entry.label, status: entry.status, initialOpenState: initialOpenState, className: calloutClass, isActive: entry.items.some(function (item) { return item.href === location.pathname; }) }, isPushed &&
-                entry.items.map(function (item) { return (React.createElement(MenuEntry, { key: item.href, secondary: true, isActive: item.href === location.pathname, onClick: handleClick },
-                    React.createElement(MenuLink, { href: item.href },
+                entry.items.map(function (item) { 
+                    var menuItemLinkProps = { href: item.href };
+                    if (item.external === true) {
+                        Object.assign(menuItemLinkProps, getExternalLinkProps());
+                    }
+                    return (React.createElement(MenuEntry, { key: item.href, secondary: true, isActive: item.href === location.pathname, onClick: handleClick },
+                    React.createElement(MenuLink, menuItemLinkProps,
                         React.createElement(LinkLabelMemo, { isPushed: isPushed }, item.label),
                         item.status && (React.createElement(LinkStatus, { color: item.status.color, fontSize: "14px" }, item.status.text))))); })));
         }

--- a/dist/index.esm.js
+++ b/dist/index.esm.js
@@ -4237,8 +4237,12 @@ var PanelBody = function (_a) {
                         React.createElement(LinkLabelMemo, { isPushed: isPushed }, item.label),
                         item.status && (React.createElement(LinkStatus, { color: item.status.color, fontSize: "14px" }, item.status.text))))); })));
         }
+        var menuLinkProps = { href: entry.href, onClick: handleClick };
+        if (entry.external === true) {
+            Object.assign(menuLinkProps, getExternalLinkProps());
+        }
         return (React.createElement(MenuEntry, { key: entry.label, isActive: entry.href === location.pathname, className: calloutClass },
-            React.createElement(MenuLink, { href: entry.href, onClick: handleClick },
+            React.createElement(MenuLink, menuLinkProps,
                 iconElement,
                 React.createElement(LinkLabelMemo, { isPushed: isPushed }, entry.label),
                 entry.status && (React.createElement(LinkStatus, { color: entry.status.color, fontSize: "14px" }, entry.status.text)))));

--- a/dist/widgets/Menu/types.d.ts
+++ b/dist/widgets/Menu/types.d.ts
@@ -21,6 +21,7 @@ export interface MenuSubEntry {
     href: string;
     calloutClass?: string;
     status?: LinkStatus;
+    external?: boolean;
 }
 export interface MenuEntry {
     label: string;

--- a/dist/widgets/Menu/types.d.ts
+++ b/dist/widgets/Menu/types.d.ts
@@ -30,6 +30,7 @@ export interface MenuEntry {
     calloutClass?: string;
     initialOpenState?: boolean;
     status?: LinkStatus;
+    external?: true;
 }
 export interface PanelProps {
     isDark: boolean;


### PR DESCRIPTION
- add `external` bool to `MenuEntry` to allow creating external links with `target=_blank` and `rel` properties

This is a prerequisite for https://trello.com/c/vve0XBAE/46-buy-fox-make-the-link-open-a-new-browser-tab