### PR TITLE
Reduce bundle size

### DIFF
--- a/dist/index.esm.js
+++ b/dist/index.esm.js
@@ -3,7 +3,7 @@ import styled, { keyframes, css, useTheme, ThemeProvider, createGlobalStyle } fr
 import { space, typography, layout, variant as variant$1, background, border, position, flexbox, grid, color } from 'styled-system';
 import get from 'lodash/get';
 import uniqueId from 'lodash/uniqueId';
-import { uniqueId as uniqueId$1 } from 'lodash';
+import uniqueId$1 from 'lodash-es/uniqueId';
 import { createPortal } from 'react-dom';
 import { usePopper } from 'react-popper';
 import noop from 'lodash/noop';

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@types/lodash": "^4.14.168",
     "@types/styled-system": "^5.1.10",
     "lodash": "^4.17.20",
+    "lodash-es": "^4.17.20",
     "react-popper": "^2.2.5",
     "react-transition-group": "^4.4.1",
     "styled-system": "^5.1.5"


### PR DESCRIPTION
- import lodash-es to use another copy of uniqueId.  Doing `import { uniqueId as uniqueId$1 } from 'lodash';` causes the whole lodash library to be imported. This is part of the effort to reduce loading time of `/vaults` page.